### PR TITLE
Add event type information in a logger info

### DIFF
--- a/ctapipe_io_magic/__init__.py
+++ b/ctapipe_io_magic/__init__.py
@@ -1223,7 +1223,7 @@ class MarsCalibratedRun:
                 first_drive_report_time = Time(drive_mjd_unique[0], scale='utc', format='mjd')
                 last_drive_report_time = Time(drive_mjd_unique[-1], scale='utc', format='mjd')
 
-                LOGGER.warning(f"Interpolating events information from {len(drive_data['mjd'])} drive reports.")
+                LOGGER.warning(f"Interpolating {event_type.replace('_', ' ')} information from {len(drive_data['mjd'])} drive reports.")
                 LOGGER.warning(f"Drive reports available from {first_drive_report_time.iso} to {last_drive_report_time.iso}.")
 
                 # Creating azimuth and zenith angles interpolators


### PR DESCRIPTION
Just add a event type information to a logger message since now we load both shower and pedestal events simultaneously in the `MarsCalibratedRun`. The information shown in the terminal is now as follows:

```
Interpolating cosmics stereo events information from 8 drive reports.
Drive reports available from 2020-12-15 21:27:17.971 to 2020-12-15 21:28:21.821.
Interpolating pedestal events information from 16 drive reports.
Drive reports available from 2020-12-15 21:27:17.971 to 2020-12-15 21:28:21.821.
```