### PR TITLE
Fixed condition of selecting a pedestal sample

### DIFF
--- a/ctapipe_io_magic/__init__.py
+++ b/ctapipe_io_magic/__init__.py
@@ -907,10 +907,10 @@ class MAGICEventSource(EventSource):
         event_time = event.trigger.tel[tel_id].time.unix
         pedestal_times = event.mon.tel[tel_id].pedestal.sample_time.unix
 
-        if np.all(pedestal_times > event_time):
+        if np.all(pedestal_times >= event_time):
             index = 0
         else:
-            index = np.where(pedestal_times <= event_time)[0][-1]
+            index = np.where(pedestal_times < event_time)[0][-1]
 
         badrmspixel_mask = []
         n_ped_types = len(event.mon.tel[tel_id].pedestal.charge_std)


### PR DESCRIPTION
Very minor fix of the condition for the pedestal sample selection. I followed the condition of the original script "MAGIC_Badpixels.py" of the magic-cta-pipe repository.