### PR TITLE
Small fix in badpixels

### DIFF
--- a/ctapipe_io_magic/__init__.py
+++ b/ctapipe_io_magic/__init__.py
@@ -948,8 +948,8 @@ class MAGICEventSource(EventSource):
                 badrmspixel_mask.append(np.zeros(len(charge_std), np.bool))
                 continue
 
-            lolim_step1 = mean_step1 / pedestal_level
-            uplim_step1 = mean_step1 * pedestal_level
+            lolim_step1 = mean_step2 / pedestal_level
+            uplim_step1 = mean_step2 * pedestal_level
             lolim_step2 = mean_step2 - pedestal_level_variance * np.sqrt(var_step2 - mean_step2 ** 2)
             uplim_step2 = mean_step2 + pedestal_level_variance * np.sqrt(var_step2 - mean_step2 ** 2)
 


### PR DESCRIPTION
In one of the last steps, a wrong meanrms is used to compute low and upper limits. This PR solves it.