### PR TITLE
updated telescope position and focal length

### DIFF
--- a/ctapipe_io_magic/__init__.py
+++ b/ctapipe_io_magic/__init__.py
@@ -71,7 +71,7 @@ MAGIC_TO_CTA_EVENT_TYPE = {
 OPTICS = OpticsDescription(
     'MAGIC',
     num_mirrors=1,
-    equivalent_focal_length=u.Quantity(16.97, u.m),
+    equivalent_focal_length=u.Quantity(17.*1.0713, u.m),
     mirror_area=u.Quantity(239.0, u.m**2),
     num_mirror_tiles=964,
 )
@@ -571,10 +571,10 @@ class MAGICEventSource(EventSource):
         # }
 
         # MAGIC telescope positions in m wrt. to the center of MAGIC simulations, from
-        # CORSIKA and reflector input card
+        # CORSIKA and reflector input card and recomputed (rotated) to be w.r.t. geographical North 
         MAGIC_TEL_POSITIONS = {
-            1: [31.80, -28.10, 0.00] * u.m,
-            2: [-31.80, 28.10, 0.00] * u.m
+            1: [34.99, -24.02, 0.00] * u.m,
+            2: [-34.99, 24.02, 0.00] * u.m
         }
 
         # camera info from MAGICCam.camgeom.fits.gz file


### PR DESCRIPTION
the telescope positions were given w.r.t. magnetic North, now they are reported w.r.t. geographical North
this was discussed in #40 

the effective focal length is now reported, to make it consistent with how it is done in MARS,
the 3cm of change of focal length due to focusing to 10 km is neglected (the effect is tiny either way),
but the factor of 1.0713 due to coma abberation is added

