### PR TITLE
Added event arrival time differences to members

### DIFF
--- a/ctapipe_io_magic/__init__.py
+++ b/ctapipe_io_magic/__init__.py
@@ -882,7 +882,7 @@ class MAGICEventSource(EventSource):
 
         Returns
         -------
-        time_diffs: numpy.ndarray
+        time_diffs: astropy.units.quantity.Quantity
             Trigger time differences of consecutive events
         """
 
@@ -897,6 +897,8 @@ class MAGICEventSource(EventSource):
             )
 
             time_diffs = np.append(time_diffs, event_info['MRawEvtHeader.fTimeDiff'])
+
+        time_diffs *= u.s
 
         return time_diffs
 

--- a/ctapipe_io_magic/__init__.py
+++ b/ctapipe_io_magic/__init__.py
@@ -215,6 +215,9 @@ class MAGICEventSource(EventSource):
         if not self.is_simulation:
             self.drive_information = self.prepare_drive_information()
 
+            # Get the arrival time differences
+            self.event_time_diffs = self.get_event_time_difference()
+
     def __exit__(self, exc_type, exc_val, exc_tb):
         """
         Releases resources (e.g. open files).
@@ -868,6 +871,34 @@ class MAGICEventSource(EventSource):
         }
 
         return drive_data
+
+    def get_event_time_difference(self):
+        """
+        Get the trigger time differences of consecutive events.
+        The time differences are computed considering all kind of events
+        (i.e., cosmic, pedestal and calibration events). However, here
+        only those of cosmic events are extracted since the others are
+        not used for dead time calculations.
+
+        Returns
+        -------
+        time_diffs: numpy.ndarray
+            Trigger time differences of consecutive events
+        """
+
+        time_diffs = np.array([])
+
+        for uproot_file in self.files_:
+
+            event_info = uproot_file['Events'].arrays(
+                expressions=['MRawEvtHeader.fTimeDiff'],
+                cut=f'(MTriggerPattern.fPrescaled == {DATA_STEREO_TRIGGER_PATTERN})',
+                library='np',
+            )
+
+            time_diffs = np.append(time_diffs, event_info['MRawEvtHeader.fTimeDiff'])
+
+        return time_diffs
 
     @property
     def subarray(self):


### PR DESCRIPTION
This pull request includes a new function to get event trigger time differences from the `MRawEvtHeader.fTimeDiff` branch, and they are stored in `self.event_time_diffs`. The time differences are computed considering all kind of events (cosmic, pedestal and calibration events), but here it extracts only those of cosmic events because the others are not used for dead time calculations. It closes #43.