### PR TITLE
Ctapipe v0.15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7]
-        ctapipe-version: [v0.12.0]
+        python-version: [3.8]
+        ctapipe-version: [v0.15.0]
 
     steps:
       - uses: actions/checkout@v2

--- a/download_test_data.sh
+++ b/download_test_data.sh
@@ -2,15 +2,15 @@
 
 set -e
 
-echo "https://data.magic.pic.es/Users/ctapipe_io_magic/test_data/real/calibrated/20210314_M1_05095172.001_Y_CrabNebula-W0.40+035.root" >  test_data_real.txt
-echo "https://data.magic.pic.es/Users/ctapipe_io_magic/test_data/real/calibrated/20210314_M1_05095172.002_Y_CrabNebula-W0.40+035.root" >> test_data_real.txt
-echo "https://data.magic.pic.es/Users/ctapipe_io_magic/test_data/real/calibrated/20210314_M2_05095172.001_Y_CrabNebula-W0.40+035.root" >> test_data_real.txt
-echo "https://data.magic.pic.es/Users/ctapipe_io_magic/test_data/real/calibrated/20210314_M2_05095172.002_Y_CrabNebula-W0.40+035.root" >> test_data_real.txt
+echo "https://webdav-magic.pic.es:8451/Users/ctapipe_io_magic/test_data/real/calibrated/20210314_M1_05095172.001_Y_CrabNebula-W0.40+035.root" >  test_data_real.txt
+echo "https://webdav-magic.pic.es:8451/Users/ctapipe_io_magic/test_data/real/calibrated/20210314_M1_05095172.002_Y_CrabNebula-W0.40+035.root" >> test_data_real.txt
+echo "https://webdav-magic.pic.es:8451/Users/ctapipe_io_magic/test_data/real/calibrated/20210314_M2_05095172.001_Y_CrabNebula-W0.40+035.root" >> test_data_real.txt
+echo "https://webdav-magic.pic.es:8451/Users/ctapipe_io_magic/test_data/real/calibrated/20210314_M2_05095172.002_Y_CrabNebula-W0.40+035.root" >> test_data_real.txt
 
-echo "https://data.magic.pic.es/Users/ctapipe_io_magic/test_data/simulated/calibrated/GA_M1_za35to50_8_824318_Y_w0.root" >  test_data_simulated.txt
-echo "https://data.magic.pic.es/Users/ctapipe_io_magic/test_data/simulated/calibrated/GA_M1_za35to50_8_824319_Y_w0.root" >> test_data_simulated.txt
-echo "https://data.magic.pic.es/Users/ctapipe_io_magic/test_data/simulated/calibrated/GA_M2_za35to50_8_824318_Y_w0.root" >> test_data_simulated.txt
-echo "https://data.magic.pic.es/Users/ctapipe_io_magic/test_data/simulated/calibrated/GA_M2_za35to50_8_824319_Y_w0.root" >> test_data_simulated.txt
+echo "https://webdav-magic.pic.es:8451/Users/ctapipe_io_magic/test_data/simulated/calibrated/GA_M1_za35to50_8_824318_Y_w0.root" >  test_data_simulated.txt
+echo "https://webdav-magic.pic.es:8451/Users/ctapipe_io_magic/test_data/simulated/calibrated/GA_M1_za35to50_8_824319_Y_w0.root" >> test_data_simulated.txt
+echo "https://webdav-magic.pic.es:8451/Users/ctapipe_io_magic/test_data/simulated/calibrated/GA_M2_za35to50_8_824318_Y_w0.root" >> test_data_simulated.txt
+echo "https://webdav-magic.pic.es:8451/Users/ctapipe_io_magic/test_data/simulated/calibrated/GA_M2_za35to50_8_824319_Y_w0.root" >> test_data_simulated.txt
 
 if [ -z "$TEST_DATA_USER" ]; then
     echo -n "Username: "

--- a/environment.yml
+++ b/environment.yml
@@ -1,13 +1,14 @@
 name: magicio
 channels:
+  - conda-forge
   - default
 dependencies:
-  - astropy>=4.0.5,<5
-  - python=3.7
-  - conda-forge::ctapipe=0.12
-  - conda-forge::eventio
-  - conda-forge::corsikaio
-  - traitlets
+  - astropy~=5.0
+  - python=3.8
+  - ctapipe=0.15
+  - eventio>=1.5.0
+  - corsikaio
+  - traitlets~=5.0,>=5.0.5
   - zeromq
   - ipython
   - numba
@@ -21,4 +22,4 @@ dependencies:
   - h5py
   - pip:
       - pytest_runner
-      - uproot~=4.1
+      - uproot~=4.2

--- a/setup.py
+++ b/setup.py
@@ -16,9 +16,13 @@ setup(
     use_scm_version={"write_to": os.path.join("ctapipe_io_magic", "_version.py")},
     packages=find_packages(),
     install_requires=[
-        'ctapipe~=0.12.0',
-        'astropy>=4.0.5,<5',
-        'uproot~=4.1',
+        'ctapipe~=0.15.0',
+        'astropy~=5.0',
+        'bokeh~=2.0',
+        'eventio>=1.5.0,<2.0.0a0',
+        'uproot~=4.2',
+        'traitlets~=5.0,>=5.0.5',
+        'tables~=3.4',
         'numpy',
         'scipy'
     ],


### PR DESCRIPTION
Updating to ctapipe v0.15 (needed to update magic-cta-pipe to same ctapipe version, in order to use gammapy v0.20).