### PR TITLE
Added the option to select the focal length type

### DIFF
--- a/ctapipe_io_magic/__init__.py
+++ b/ctapipe_io_magic/__init__.py
@@ -128,8 +128,8 @@ class MAGICEventSource(EventSource):
 
     focal_length_choice = CaselessStrEnum(
         ['nominal', 'effective'],
-        default_value='nominal',
-        help='which focal length to use when constructing the SubarrayDescription',
+        default_value='effective',
+        help='Which focal length to use when constructing the SubarrayDescription.',
     ).tag(config=True)
 
     def __init__(self, input_url=None, config=None, parent=None, **kwargs):
@@ -579,6 +579,7 @@ class MAGICEventSource(EventSource):
         }
 
         if self.focal_length_choice == 'effective':
+            # Use the effective focal length that the coma aberration is corrected
             focal_length = u.Quantity(17*1.0713, u.m)
         else:
             focal_length = u.Quantity(17, u.m)

--- a/ctapipe_io_magic/__init__.py
+++ b/ctapipe_io_magic/__init__.py
@@ -18,7 +18,7 @@ from pkg_resources import resource_filename
 
 from ctapipe.io import EventSource, DataLevel
 from ctapipe.core import Container, Field, Provenance
-from ctapipe.core.traits import Bool
+from ctapipe.core.traits import Bool, CaselessStrEnum
 from ctapipe.coordinates import CameraFrame
 
 from ctapipe.containers import (
@@ -67,14 +67,6 @@ MAGIC_TO_CTA_EVENT_TYPE = {
     DATA_STEREO_TRIGGER_PATTERN: EventType.SUBARRAY,
     PEDESTAL_TRIGGER_PATTERN: EventType.SKY_PEDESTAL,
 }
-
-OPTICS = OpticsDescription(
-    'MAGIC',
-    num_mirrors=1,
-    equivalent_focal_length=u.Quantity(17.*1.0713, u.m),
-    mirror_area=u.Quantity(239.0, u.m**2),
-    num_mirror_tiles=964,
-)
 
 
 def load_camera_geometry():
@@ -130,8 +122,14 @@ class MAGICEventSource(EventSource):
     ).tag(config=True)
 
     use_pedestals = Bool(
-           default_value=False,
-           help='Extract pedestal events instead of cosmic events.'
+        default_value=False,
+        help='Extract pedestal events instead of cosmic events.'
+    ).tag(config=True)
+
+    focal_length_choice = CaselessStrEnum(
+        ['nominal', 'effective'],
+        default_value='nominal',
+        help='which focal length to use when constructing the SubarrayDescription',
     ).tag(config=True)
 
     def __init__(self, input_url=None, config=None, parent=None, **kwargs):
@@ -574,11 +572,24 @@ class MAGICEventSource(EventSource):
         # }
 
         # MAGIC telescope positions in m wrt. to the center of MAGIC simulations, from
-        # CORSIKA and reflector input card and recomputed (rotated) to be w.r.t. geographical North 
+        # CORSIKA and reflector input card and recomputed (rotated) to be w.r.t. geographical North
         MAGIC_TEL_POSITIONS = {
             1: [34.99, -24.02, 0.00] * u.m,
             2: [-34.99, 24.02, 0.00] * u.m
         }
+
+        if self.focal_length_choice == 'effective':
+            focal_length = u.Quantity(17*1.0713, u.m)
+        else:
+            focal_length = u.Quantity(17, u.m)
+
+        OPTICS = OpticsDescription(
+            'MAGIC',
+            num_mirrors=1,
+            equivalent_focal_length=focal_length,
+            mirror_area=u.Quantity(239.0, u.m**2),
+            num_mirror_tiles=964,
+        )
 
         # camera info from MAGICCam.camgeom.fits.gz file
         camera_geom = load_camera_geometry()

--- a/ctapipe_io_magic/tests/test_magic_event_source.py
+++ b/ctapipe_io_magic/tests/test_magic_event_source.py
@@ -233,6 +233,23 @@ def test_geom(dataset):
         assert source.subarray.tels[2].camera.geometry.pix_x.size == 1039
 
 
+@pytest.mark.parametrize('dataset', test_calibrated_all)
+def test_focal_length_choice(dataset):
+    from astropy import units as u
+    from ctapipe_io_magic import MAGICEventSource
+
+    with MAGICEventSource(input_url=dataset, process_run=False, focal_length_choice='nominal') as source:
+        assert source.subarray.tel[1].optics.equivalent_focal_length == u.Quantity(17, u.m)
+        assert source.subarray.tel[2].optics.equivalent_focal_length == u.Quantity(17, u.m)
+        assert source.subarray.tel[1].camera.geometry.frame.focal_length == u.Quantity(17, u.m)
+        assert source.subarray.tel[2].camera.geometry.frame.focal_length == u.Quantity(17, u.m)
+
+    with MAGICEventSource(input_url=dataset, process_run=False, focal_length_choice='effective') as source:
+        assert source.subarray.tel[1].optics.equivalent_focal_length == u.Quantity(17*1.0713, u.m)
+        assert source.subarray.tel[2].optics.equivalent_focal_length == u.Quantity(17*1.0713, u.m)
+        assert source.subarray.tel[1].camera.geometry.frame.focal_length == u.Quantity(17*1.0713, u.m)
+        assert source.subarray.tel[2].camera.geometry.frame.focal_length == u.Quantity(17*1.0713, u.m)
+
 # def test_eventseeker():
 #    dataset = get_dataset_path("20131004_M1_05029747.003_Y_MagicCrab-W0.40+035.root")
 #


### PR DESCRIPTION
This pull request implements the option "focal_length_choice" to select the "nominal" or "effective" focal length when constructing the SubarrayDescription. Since ctapipe v0.12 which is used in the current version of magic-cta-pipe gives the "nominal" focal length by default for simulation data, here the default value is also set to the "nominal". This pull request is related to the one #cta-observatory/magic-cta-pipe#72. 