### PR TITLE
Do not mix default and conda-forge channel.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,6 @@
 name: magicio
 channels:
   - conda-forge
-  - default
 dependencies:
   - astropy=5
   - python=3.11


### PR DESCRIPTION
As per https://conda-forge.org/docs/user/tipsandtricks.html, it is better not to mix packages from the `conda-forge` and `default` channels. See also https://github.com/cta-observatory/cta-lstchain/pull/1126 from `lstchain`