### PR TITLE
Use setup-micromamba action.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,10 +37,9 @@ jobs:
           sed -i -e "s/- python=.*/- python=$PYTHON_VERSION/g" environment.yml
 
       - name: Create and activate env
-        uses: mamba-org/provision-with-micromamba@v14
+        uses: mamba-org/setup-micromamba@v1
         with:
           cache-downloads: true
-          environment-name: magicio
           environment-file: environment.yml
 
       - name: install


### PR DESCRIPTION
According to https://github.com/mamba-org/provision-with-micromamba , the `provision-with-micromamba` is deprecated. Now `setup-micromamba` is the recommended one (https://github.com/mamba-org/setup-micromamba)