### PR TITLE
Add file check for Events and RunHeaders trees.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
-        ctapipe-version: ["v0.19.2",]
+        python-version: ["3.9", "3.10", "3.11"]
+        ctapipe-version: ["v0.19.2"]
 
     defaults:
       run:

--- a/ctapipe_io_magic/__init__.py
+++ b/ctapipe_io_magic/__init__.py
@@ -185,7 +185,6 @@ class MAGICEventSource(EventSource):
 
         self.file_list = []
         self.file_list_drive = []
-        self.excluded_files_ = []
 
         for file_path in ls:
             if (
@@ -296,8 +295,6 @@ class MAGICEventSource(EventSource):
         """
 
         for rootf in self.files_:
-            rootf.close()
-        for rootf in self.excluded_files_:
             rootf.close()
 
     @staticmethod
@@ -449,6 +446,8 @@ class MAGICEventSource(EventSource):
             )
             return False
 
+        num_invalid_files = 0
+
         for rootf in self.files_:
             for tree in needed_trees:
                 if tree not in rootf.keys(cycle=False):
@@ -457,18 +456,16 @@ class MAGICEventSource(EventSource):
                     )
                     if tree == "RunHeaders" or tree == "Events":
                         logger.error(
-                            f"Cannot proceed without RunHeaders or Events tree. "
-                            f"File {rootf.file_path} will be excluded."
+                            f"File {rootf.file_path} does not have a {tree} tree. "
+                            f"Please check the file and try again. If the file "
+                            f"cannot be recovered, exclude it from the analysis."
                         )
-                        self.files_.remove(rootf)
-                        self.excluded_files_.append(rootf)
-                        break
+                        num_invalid_files += 1
 
-        if len(self.excluded_files_) == num_files:
-            logger.error("All input files were excluded.")
+        if num_invalid_files > 0:
             return False
-
-        return True
+        else:
+            return True
 
     def parse_run_info(self):
         """

--- a/ctapipe_io_magic/__init__.py
+++ b/ctapipe_io_magic/__init__.py
@@ -44,6 +44,11 @@ from ctapipe.instrument import (
 )
 
 from .mars_datalevels import MARSDataLevel
+from .exceptions import (
+    MissingInputFilesError,
+    FailedFileCheckError,
+    MissingDriveReportError,
+)
 from .version import __version__
 
 from .constants import (
@@ -57,7 +62,14 @@ from .constants import (
     DATA_MAGIC_LST_TRIGGER,
 )
 
-__all__ = ["MAGICEventSource", "MARSDataLevel", "__version__"]
+__all__ = [
+    "MAGICEventSource",
+    "MARSDataLevel",
+    "MissingInputFilesError",
+    "FailedFileCheckError",
+    "MissingDriveReportError",
+    "__version__",
+]
 
 logger = logging.getLogger(__name__)
 

--- a/ctapipe_io_magic/__init__.py
+++ b/ctapipe_io_magic/__init__.py
@@ -441,12 +441,12 @@ class MAGICEventSource(EventSource):
         return run_number, is_mc, telescope, datalevel
 
     def check_files(self):
-        """Check the the input files contain needed trees."""
+        """Check the the input files contain the needed trees."""
 
         needed_trees = ["RunHeaders", "Events"]
         num_files = len(self.files_)
 
-        if num_files == 1 and "Drive" not in self.files_[0]:
+        if num_files == 1 and "Drive" not in self.files_[0].keys(cycle=False):
             logger.error(f"Cannot proceed without Drive information for a single file.")
             return False
 

--- a/ctapipe_io_magic/__init__.py
+++ b/ctapipe_io_magic/__init__.py
@@ -446,12 +446,22 @@ class MAGICEventSource(EventSource):
         needed_trees = ["RunHeaders", "Events"]
         num_files = len(self.files_)
 
-        if num_files == 1 and "Drive" not in self.files_[0].keys(cycle=False):
+        if (
+            num_files == 1
+            and "Drive" not in self.files_[0].keys(cycle=False)
+            and "OriginalMC" not in self.files_[0].keys(cycle=False)
+        ):
             logger.error(f"Cannot proceed without Drive information for a single file.")
             return False
 
-        if num_files == 1 and "Trigger" not in self.files_[0].keys(cycle=False):
-            logger.error(f"Cannot proceed without Trigger information for a single file.")
+        if (
+            num_files == 1
+            and "Trigger" not in self.files_[0].keys(cycle=False)
+            and "OriginalMC" not in self.files_[0].keys(cycle=False)
+        ):
+            logger.error(
+                f"Cannot proceed without Trigger information for a single file."
+            )
             return False
 
         for rootf in self.files_:

--- a/ctapipe_io_magic/__init__.py
+++ b/ctapipe_io_magic/__init__.py
@@ -436,7 +436,7 @@ class MAGICEventSource(EventSource):
             and "Drive" not in self.files_[0].keys(cycle=False)
             and "OriginalMC" not in self.files_[0].keys(cycle=False)
         ):
-            logger.error(f"Cannot proceed without Drive information for a single file.")
+            logger.error("Cannot proceed without Drive information for a single file.")
             return False
 
         if (
@@ -445,7 +445,7 @@ class MAGICEventSource(EventSource):
             and "OriginalMC" not in self.files_[0].keys(cycle=False)
         ):
             logger.error(
-                f"Cannot proceed without Trigger information for a single file."
+                "Cannot proceed without Trigger information for a single file."
             )
             return False
 
@@ -457,11 +457,9 @@ class MAGICEventSource(EventSource):
                     )
                     if tree == "RunHeaders" or tree == "Events":
                         logger.error(
-                            f"Cannot proceed without RunHeaders or Events tree."
+                            f"Cannot proceed without RunHeaders or Events tree. "
                             f"File {rootf.file_path} will be excluded."
                         )
-                        self.file_list.remove(rootf.file_path)
-                        self.file_list_drive.remove(rootf.file_path)
                         self.files_.remove(rootf)
                         self.excluded_files_.append(rootf)
                         break

--- a/ctapipe_io_magic/__init__.py
+++ b/ctapipe_io_magic/__init__.py
@@ -450,6 +450,10 @@ class MAGICEventSource(EventSource):
             logger.error(f"Cannot proceed without Drive information for a single file.")
             return False
 
+        if num_files == 1 and "Trigger" not in self.files_[0].keys(cycle=False):
+            logger.error(f"Cannot proceed without Trigger information for a single file.")
+            return False
+
         for rootf in self.files_:
             for tree in needed_trees:
                 if tree not in rootf.keys(cycle=False):

--- a/ctapipe_io_magic/__init__.py
+++ b/ctapipe_io_magic/__init__.py
@@ -100,33 +100,6 @@ def load_camera_geometry():
     return CameraGeometry.from_table(f)
 
 
-class MissingInputFilesError(Exception):
-    """
-    Exception raised when the files check fails.
-    """
-
-    def __init__(self, message):
-        self.message = message
-
-
-class FailedFileCheckError(Exception):
-    """
-    Exception raised when the files check fails.
-    """
-
-    def __init__(self, message):
-        self.message = message
-
-
-class MissingDriveReportError(Exception):
-    """
-    Exception raised when a subrun does not have drive reports.
-    """
-
-    def __init__(self, message):
-        self.message = message
-
-
 class MAGICEventSource(EventSource):
     """
     EventSource for MAGIC calibrated data.

--- a/ctapipe_io_magic/exceptions.py
+++ b/ctapipe_io_magic/exceptions.py
@@ -1,0 +1,25 @@
+class MissingInputFilesError(Exception):
+    """
+    Exception raised when there are no input files.
+    """
+
+    def __init__(self, message):
+        self.message = message
+
+
+class FailedFileCheckError(Exception):
+    """
+    Exception raised when the files check fails.
+    """
+
+    def __init__(self, message):
+        self.message = message
+
+
+class MissingDriveReportError(Exception):
+    """
+    Exception raised when a subrun does not have drive reports.
+    """
+
+    def __init__(self, message):
+        self.message = message

--- a/ctapipe_io_magic/exceptions.py
+++ b/ctapipe_io_magic/exceptions.py
@@ -3,8 +3,7 @@ class MissingInputFilesError(Exception):
     Exception raised when there are no input files.
     """
 
-    def __init__(self, message):
-        self.message = message
+    pass
 
 
 class FailedFileCheckError(Exception):
@@ -12,8 +11,7 @@ class FailedFileCheckError(Exception):
     Exception raised when the files check fails.
     """
 
-    def __init__(self, message):
-        self.message = message
+    pass
 
 
 class MissingDriveReportError(Exception):
@@ -21,5 +19,4 @@ class MissingDriveReportError(Exception):
     Exception raised when a subrun does not have drive reports.
     """
 
-    def __init__(self, message):
-        self.message = message
+    pass

--- a/ctapipe_io_magic/tests/test_magic_event_source.py
+++ b/ctapipe_io_magic/tests/test_magic_event_source.py
@@ -28,6 +28,11 @@ test_calibrated_real_only_runh = [
     / "20210314_M1_05095173.001_Y_CrabNebula-W0.40+035_only_runh.root",
 ]
 
+test_calibrated_real_only_trigger = [
+    test_calibrated_real_dir
+    / "20210314_M1_05095173.001_Y_CrabNebula-W0.40+035_only_trigger.root",
+]
+
 test_calibrated_real_hast = [
     test_calibrated_real_dir / "20230324_M1_05106879.001_Y_1ES0806+524-W0.40+000.root",
     test_calibrated_real_dir / "20230324_M1_05106879.002_Y_1ES0806+524-W0.40+000.root",
@@ -51,6 +56,7 @@ test_calibrated_missing_trees = (
     test_calibrated_real_only_events
     + test_calibrated_real_only_drive
     + test_calibrated_real_only_runh
+    + test_calibrated_real_only_trigger
 )
 
 data_dict = dict()

--- a/ctapipe_io_magic/tests/test_magic_event_source.py
+++ b/ctapipe_io_magic/tests/test_magic_event_source.py
@@ -15,17 +15,17 @@ test_calibrated_real = [
 
 test_calibrated_real_only_events = [
     test_calibrated_real_dir
-    / "20210314_M1_05095172.001_Y_CrabNebula-W0.40+035_only_events.root",
+    / "20210314_M1_05095173.001_Y_CrabNebula-W0.40+035_only_events.root",
 ]
 
 test_calibrated_real_only_drive = [
     test_calibrated_real_dir
-    / "20210314_M1_05095172.001_Y_CrabNebula-W0.40+035_only_drive.root",
+    / "20210314_M1_05095173.001_Y_CrabNebula-W0.40+035_only_drive.root",
 ]
 
 test_calibrated_real_only_runh = [
     test_calibrated_real_dir
-    / "20210314_M1_05095172.001_Y_CrabNebula-W0.40+035_only_runh.root",
+    / "20210314_M1_05095173.001_Y_CrabNebula-W0.40+035_only_runh.root",
 ]
 
 test_calibrated_real_hast = [

--- a/ctapipe_io_magic/tests/test_magic_event_source.py
+++ b/ctapipe_io_magic/tests/test_magic_event_source.py
@@ -13,6 +13,21 @@ test_calibrated_real = [
     test_calibrated_real_dir / "20210314_M2_05095172.002_Y_CrabNebula-W0.40+035.root",
 ]
 
+test_calibrated_real_only_events = [
+    test_calibrated_real_dir
+    / "20210314_M1_05095172.001_Y_CrabNebula-W0.40+035_only_events.root",
+]
+
+test_calibrated_real_only_drive = [
+    test_calibrated_real_dir
+    / "20210314_M1_05095172.001_Y_CrabNebula-W0.40+035_only_drive.root",
+]
+
+test_calibrated_real_only_runh = [
+    test_calibrated_real_dir
+    / "20210314_M1_05095172.001_Y_CrabNebula-W0.40+035_only_runh.root",
+]
+
 test_calibrated_real_hast = [
     test_calibrated_real_dir / "20230324_M1_05106879.001_Y_1ES0806+524-W0.40+000.root",
     test_calibrated_real_dir / "20230324_M1_05106879.002_Y_1ES0806+524-W0.40+000.root",
@@ -30,6 +45,12 @@ test_calibrated_simulated = [
 
 test_calibrated_all = (
     test_calibrated_real + test_calibrated_simulated + test_calibrated_real_hast
+)
+
+test_calibrated_missing_trees = (
+    test_calibrated_real_only_events
+    + test_calibrated_real_only_drive
+    + test_calibrated_real_only_runh
 )
 
 data_dict = dict()
@@ -335,9 +356,18 @@ def test_number_of_events(dataset):
                     count_2_tel_m1_m2 += 1
 
             assert count_3_tel == data_dict[source.input_url.name]["n_events_3_tel"]
-            assert count_2_tel_m1_lst == data_dict[source.input_url.name]["n_events_2_tel_m1_lst"]
-            assert count_2_tel_m2_lst == data_dict[source.input_url.name]["n_events_2_tel_m2_lst"]
-            assert count_2_tel_m1_m2 == data_dict[source.input_url.name]["n_events_2_tel_m1_m2"]
+            assert (
+                count_2_tel_m1_lst
+                == data_dict[source.input_url.name]["n_events_2_tel_m1_lst"]
+            )
+            assert (
+                count_2_tel_m2_lst
+                == data_dict[source.input_url.name]["n_events_2_tel_m2_lst"]
+            )
+            assert (
+                count_2_tel_m1_m2
+                == data_dict[source.input_url.name]["n_events_2_tel_m1_m2"]
+            )
 
         # if '_M1_' in dataset.name:
         #     assert run['data'].n_cosmics_stereo_events_m1 == data_dict[source.input_url.name]['n_events_stereo']
@@ -475,6 +505,24 @@ def test_focal_length_choice(dataset):
         )
         assert source.subarray.tel[2].camera.geometry.frame.focal_length == u.Quantity(
             17 * 1.0713, u.m
+        )
+
+
+@pytest.mark.parametrize("dataset", test_calibrated_missing_trees)
+def test_check_files(dataset):
+    from ctapipe_io_magic import MAGICEventSource, FailedFileCheckError
+
+    with pytest.raises(FailedFileCheckError):
+        MAGICEventSource(input_url=dataset, process_run=False)
+
+
+def test_check_missing_files():
+    from ctapipe_io_magic import MAGICEventSource, MissingInputFilesError
+
+    with pytest.raises(MissingInputFilesError):
+        MAGICEventSource(
+            input_url="20501312_M1_05095172.001_Y_FakeSource-W0.40+035.root",
+            process_run=False,
         )
 
 

--- a/download_test_data.sh
+++ b/download_test_data.sh
@@ -13,6 +13,7 @@ echo "https://www.magic.iac.es/mcp-testdata/test_data/real/calibrated/20230324_M
 echo "https://www.magic.iac.es/mcp-testdata/test_data/real/calibrated/20210314_M1_05095173.001_Y_CrabNebula-W0.40+035_only_events.root" >>  test_data_real.txt
 echo "https://www.magic.iac.es/mcp-testdata/test_data/real/calibrated/20210314_M1_05095173.001_Y_CrabNebula-W0.40+035_only_drive.root" >>  test_data_real.txt
 echo "https://www.magic.iac.es/mcp-testdata/test_data/real/calibrated/20210314_M1_05095173.001_Y_CrabNebula-W0.40+035_only_runh.root" >>  test_data_real.txt
+echo "https://www.magic.iac.es/mcp-testdata/test_data/real/calibrated/20210314_M1_05095173.001_Y_CrabNebula-W0.40+035_only_trigger.root" >>  test_data_real.txt
 
 echo "https://www.magic.iac.es/mcp-testdata/test_data/simulated/calibrated/GA_M1_za35to50_8_824318_Y_w0.root" >  test_data_simulated.txt
 echo "https://www.magic.iac.es/mcp-testdata/test_data/simulated/calibrated/GA_M1_za35to50_8_824319_Y_w0.root" >> test_data_simulated.txt

--- a/download_test_data.sh
+++ b/download_test_data.sh
@@ -10,9 +10,9 @@ echo "https://www.magic.iac.es/mcp-testdata/test_data/real/calibrated/20230324_M
 echo "https://www.magic.iac.es/mcp-testdata/test_data/real/calibrated/20230324_M1_05106879.002_Y_1ES0806+524-W0.40+000.root" >>  test_data_real.txt
 echo "https://www.magic.iac.es/mcp-testdata/test_data/real/calibrated/20230324_M2_05106879.001_Y_1ES0806+524-W0.40+000.root" >>  test_data_real.txt
 echo "https://www.magic.iac.es/mcp-testdata/test_data/real/calibrated/20230324_M2_05106879.002_Y_1ES0806+524-W0.40+000.root" >>  test_data_real.txt
-echo "https://www.magic.iac.es/mcp-testdata/test_data/real/calibrated/20210314_M1_05095172.001_Y_CrabNebula-W0.40+035_only_events.root" >>  test_data_real.txt
-echo "https://www.magic.iac.es/mcp-testdata/test_data/real/calibrated/20210314_M1_05095172.001_Y_CrabNebula-W0.40+035_only_drive.root" >>  test_data_real.txt
-echo "https://www.magic.iac.es/mcp-testdata/test_data/real/calibrated/20210314_M1_05095172.001_Y_CrabNebula-W0.40+035_only_runh.root" >>  test_data_real.txt
+echo "https://www.magic.iac.es/mcp-testdata/test_data/real/calibrated/20210314_M1_05095173.001_Y_CrabNebula-W0.40+035_only_events.root" >>  test_data_real.txt
+echo "https://www.magic.iac.es/mcp-testdata/test_data/real/calibrated/20210314_M1_05095173.001_Y_CrabNebula-W0.40+035_only_drive.root" >>  test_data_real.txt
+echo "https://www.magic.iac.es/mcp-testdata/test_data/real/calibrated/20210314_M1_05095173.001_Y_CrabNebula-W0.40+035_only_runh.root" >>  test_data_real.txt
 
 echo "https://www.magic.iac.es/mcp-testdata/test_data/simulated/calibrated/GA_M1_za35to50_8_824318_Y_w0.root" >  test_data_simulated.txt
 echo "https://www.magic.iac.es/mcp-testdata/test_data/simulated/calibrated/GA_M1_za35to50_8_824319_Y_w0.root" >> test_data_simulated.txt

--- a/download_test_data.sh
+++ b/download_test_data.sh
@@ -10,6 +10,9 @@ echo "https://www.magic.iac.es/mcp-testdata/test_data/real/calibrated/20230324_M
 echo "https://www.magic.iac.es/mcp-testdata/test_data/real/calibrated/20230324_M1_05106879.002_Y_1ES0806+524-W0.40+000.root" >>  test_data_real.txt
 echo "https://www.magic.iac.es/mcp-testdata/test_data/real/calibrated/20230324_M2_05106879.001_Y_1ES0806+524-W0.40+000.root" >>  test_data_real.txt
 echo "https://www.magic.iac.es/mcp-testdata/test_data/real/calibrated/20230324_M2_05106879.002_Y_1ES0806+524-W0.40+000.root" >>  test_data_real.txt
+echo "https://www.magic.iac.es/mcp-testdata/test_data/real/calibrated/20210314_M1_05095172.001_Y_CrabNebula-W0.40+035_only_events.root" >>  test_data_real.txt
+echo "https://www.magic.iac.es/mcp-testdata/test_data/real/calibrated/20210314_M1_05095172.001_Y_CrabNebula-W0.40+035_only_drive.root" >>  test_data_real.txt
+echo "https://www.magic.iac.es/mcp-testdata/test_data/real/calibrated/20210314_M1_05095172.001_Y_CrabNebula-W0.40+035_only_runh.root" >>  test_data_real.txt
 
 echo "https://www.magic.iac.es/mcp-testdata/test_data/simulated/calibrated/GA_M1_za35to50_8_824318_Y_w0.root" >  test_data_simulated.txt
 echo "https://www.magic.iac.es/mcp-testdata/test_data/simulated/calibrated/GA_M1_za35to50_8_824319_Y_w0.root" >> test_data_simulated.txt


### PR DESCRIPTION
As per the title, this PR adds a check for the RunHeaders and Events trees in the input file. If a file is found without one of the two, then it is excluded from processing (and also excluded from the drive interpolation).